### PR TITLE
Better detect the Authorization header in FastCGI environments

### DIFF
--- a/OAuth.php
+++ b/OAuth.php
@@ -829,6 +829,10 @@ class OAuthUtil {
           $out[$key] = $value;
         }
       }
+      // The "Authorization" header may get turned into "Auth".
+      if ($out['Auth']) {
+        $out['Authorization'] = $out['Auth'];
+      }
     }
     return $out;
   }


### PR DESCRIPTION
In situations where apache_request_headers() is not available (such as under FastCGI) the "Authorization" header may show up as $_SERVER['HTTP_AUTH']. The existing code changes HTTP_AUTH to Auth, but since Auth isn't the correct name for the header, the request fails. This pull request changes the header name from Auth back to Authorization, which is what the calling code is looking for as a header name.

Without this change, servers with FastCGI may not be able to accept oAuth requests using the Authorization header.
